### PR TITLE
Inhibite the message that appears in minibuffer on every opened file

### DIFF
--- a/recently.el
+++ b/recently.el
@@ -69,12 +69,13 @@
   "Write to file."
   ;; Failsafe to avoid purging all existing entries
   (cl-assert recently--list)
-  (with-temp-buffer
-    (prin1 recently--list
-           (current-buffer))
-    (write-region (point-min)
-                  (point-max)
-                  recently-file)))
+  (let ((inhibit-message t))
+    (with-temp-buffer
+      (prin1 recently--list
+             (current-buffer))
+      (write-region (point-min)
+                    (point-max)
+                    recently-file))))
 
 (defun recently--read ()
   "Read file."


### PR DESCRIPTION
The C `write-region` function that we use, emits a message.  This can
be only disabled if we were auto-saving or running noninteractively.
None of that is true, so the easiest way forward is to use
`inhibit-message`.